### PR TITLE
[5.9] Adds paths to errors namespace.

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -392,7 +392,7 @@ class Handler implements ExceptionHandlerContract
     {
         $paths = collect(config('view.paths'));
 
-        View::replaceNamespace('errors', $paths->map(function ($path) {
+        View::addNamespace('errors', $paths->map(function ($path) {
             return "{$path}/errors";
         })->push(__DIR__.'/views')->all());
     }


### PR DESCRIPTION
It extends existed paths for errors namespace instead replacement.

I added namespaces for errors manually. replaceNamespace rewrite my paths and I cannot use views from theme.